### PR TITLE
Callbacks and Async with ActiveJobs

### DIFF
--- a/lib/redisearch-rails.rb
+++ b/lib/redisearch-rails.rb
@@ -6,8 +6,17 @@ require 'redi_searcher'
 
 module RediSearch
   autoload :RediSearchable, 'redisearch-rails/redisearchable'
+  autoload :BatchesIndexer, 'redisearch-rails/batches_indexer'
+  autoload :RecordIndexer, 'redisearch-rails/record_indexer'
+
+  #jobs
+  autoload :ReindexRecordJob, 'redisearch-rails/reindex_record_job'
+  autoload :ReindexBatchesJob, 'redisearch-rails/reindex_batches_job'
+
+  DEFAULT_BATCH_SIZE = 1_000
 
   class << self
+    attr_accessor :models
     attr_writer :configuration
 
     def configuration
@@ -22,7 +31,55 @@ module RediSearch
       @client ||= RediSearcher::Client.new(configuration.redis_config)
     end
 
+    def enable_callbacks
+      self.callbacks_value = nil
+    end
+
+    def disable_callbacks
+      self.callbacks_value = false
+    end
+
+    def callbacks?(default: true)
+      if self.callbacks_value.nil?
+        default
+      else
+        self.callbacks_value != false
+      end
+    end
+
+    def callbacks_value
+      Thread.current[:redisearch_callbacks_enabled]
+    end
+
+    def callbacks_value=(value)
+      Thread.current[:redisearch_callbacks_enabled] = value
+    end
+
+    def callbacks(value)
+      if block_given?
+        previous_value = self.callbacks_value
+        begin
+          self.callbacks_value = value
+          result = yield
+          result
+        ensure
+          self.callbacks_value = previous_value
+        end
+      else
+        self.callbacks_value = value
+      end
+    end
+
+    private
+
+    def method_missing(m, *args, &block)
+      return configuration.send(m) if configuration.respond_to?(m)
+      super
+    end
   end
+
+  @models = []
+
 end
 
 ActiveSupport.on_load(:active_record) do

--- a/lib/redisearch-rails/batches_indexer.rb
+++ b/lib/redisearch-rails/batches_indexer.rb
@@ -1,0 +1,44 @@
+module RediSearch
+  class BatchesIndexer
+
+    attr_reader :klass
+
+    def initialize(klass)
+      @klass = klass
+      @index = klass.redisearch_index
+    end
+
+    def reindex(mode: :inline, **options)
+      unless [:inline, true, :async].include?(mode)
+        raise ArgumentError, "#{mode} its not a valid value for mode"
+      end
+
+      batch_size = klass.redisearch_index_options[:batch_size] || DEFAULT_BATCH_SIZE
+
+      #this make a select count
+      size = klass.redisearch_import.find_in_batches(batch_size: batch_size).size
+      case mode
+      when :async
+        for i in 1..size
+          start = (i-1)*batch_size
+          finish = (i*batch_size)-1
+          RediSearch::ReindexBatchesJob.perform_later(klass.name, start.to_s, finish.to_s, batch_size.to_s)
+        end
+      else
+        reindex_in_batches(batch_size, options)
+      end
+    end
+
+    private
+
+    def reindex_in_batches(batch_size, **options)
+      klass.redisearch_import.find_in_batches(batch_size: batch_size) do |records|
+        klass.redisearch_index.client.multi do
+          records.each do |record|
+            record.reindex(mode: :inline, **options.deep_merge(replace: true, partial: true))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/redisearch-rails/configuration.rb
+++ b/lib/redisearch-rails/configuration.rb
@@ -1,9 +1,13 @@
 module RediSearch
   class Configuration
-    attr_accessor :redis_config
+    attr_accessor :redis_config, :index_prefix, :index_suffix, :queue_name, :model_options
 
     def initialize
       @redis_config = {}
+      @index_prefix = nil
+      @index_suffix = nil
+      @queue_name = :redisearch
+      @model_options = {}
     end
   end
 end

--- a/lib/redisearch-rails/record_indexer.rb
+++ b/lib/redisearch-rails/record_indexer.rb
@@ -1,0 +1,37 @@
+module RediSearch
+  class RecordIndexer
+
+    attr_reader :record, :index
+
+    def initialize(record)
+      @record = record
+      @index = record.class.redisearch_index
+    end
+
+    def reindex(mode: nil, **options)
+      unless [:inline, true, nil, :async].include?(mode)
+        raise ArgumentError, "#{mode} its not a valid value for mode"
+      end
+
+      mode ||= RediSearch.callbacks_value || record.class.redisearch_index_options[:callbacks] || true
+
+      case mode
+      when :async
+        RediSearch::ReindexRecordJob.perform_later(record.class.name, record.id.to_s)
+      else
+        reindex_record
+      end
+    end
+
+    private
+
+    def reindex_record
+      if record.destroyed? || !record.persisted? || !record.should_index?
+        document = index.generate_document(record.redisearch_document_id, {})
+        document.del(dd: true)
+      else
+        record.redisearch_add
+      end
+    end
+  end
+end

--- a/lib/redisearch-rails/redisearchable/instance_methods.rb
+++ b/lib/redisearch-rails/redisearchable/instance_methods.rb
@@ -6,6 +6,27 @@ module RediSearch
         @redisearch_document ||= generate_redisearch_document
       end
 
+      def redisearch_reindex(**options)
+        RediSearch::RecordIndexer.new(self).reindex(options)
+      end
+      alias_method :reindex, :redisearch_reindex unless method_defined?(:reindex)
+
+      def should_index?
+        true
+      end
+
+      def redisearch_add
+        redisearch_document.add(replace: true, partial: true)
+      end
+
+      def redisearch_delete
+        redisearch_document.del(dd: true)
+      end
+
+      def redisearch_document_id
+        [self.class.redisearch_index.name, self.id].join('_')
+      end
+
       private
 
       def generate_redisearch_document
@@ -14,10 +35,6 @@ module RediSearch
         fields = index.schema.fields.map(&:name)
         fields_values = Hash[fields.flatten.map! { |field| [field, serializer.public_send(field)] }]
         index.generate_document(redisearch_document_id, fields_values)
-      end
-
-      def redisearch_document_id
-        [self.class.redisearch_index.name, self.id].join('_')
       end
 
       def redisearch_serializer

--- a/lib/redisearch-rails/reindex_batches_job.rb
+++ b/lib/redisearch-rails/reindex_batches_job.rb
@@ -1,0 +1,26 @@
+module RediSearch
+  class ReindexBatchesJob < ActiveJob::Base
+    queue_as { RediSearch.queue_name }
+
+    def perform(klass, start, finish, batch_size)
+      klass = klass.constantize
+
+      batches_relation = nil
+
+      if ActiveRecord::VERSION::STRING >= "5.0"
+        batches_relation = klass.redisearch_import.find_in_batches(batch_size: batch_size, start: start, finish: finish)
+      else
+        batches_relation = klass.redisearch_import.where(klass.arel_table[:id].lteq(finish.to_i)).find_in_batches(batch_size: batch_size, start: start)
+      end
+
+      batches_relation.each do |records|
+        klass.redisearch_index.client.multi do
+          records.each do |record|
+            record.reindex(mode: :inline, replace: true)
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/redisearch-rails/reindex_record_job.rb
+++ b/lib/redisearch-rails/reindex_record_job.rb
@@ -1,0 +1,30 @@
+module RediSearch
+  class ReindexRecordJob < ActiveJob::Base
+    RECORD_NOT_FOUND_CLASSES = [
+      "ActiveRecord::RecordNotFound"
+    ]
+
+    queue_as { RediSearch.queue_name }
+
+    def perform(klass, id)
+      model = klass.constantize
+
+      record =
+        begin
+          model.redisearch_import.find(id)
+        rescue => e
+          # check by name rather than rescue directly so we don't need
+          # to determine which classes are defined
+          raise e unless RECORD_NOT_FOUND_CLASSES.include?(e.class.name)
+          nil
+        end
+
+        unless record
+          record = model.new
+          record.id = id
+        end
+
+      RecordIndexer.new(record).reindex(mode: :inline)
+    end
+  end
+end

--- a/redisearch-rails.gemspec
+++ b/redisearch-rails.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activerecord', '~> 4.2'
   spec.add_dependency 'activesupport', '~> 4.2'
+  spec.add_dependency 'activejob', '~> 4.2'
   spec.add_dependency 'redi_searcher', '~> 0.1', '>= 0.1.3'
 
   spec.add_development_dependency "bundler", "~> 1.17"

--- a/spec/redisearch-rails/callbacks_spec.rb
+++ b/spec/redisearch-rails/callbacks_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+describe RediSearch do
+  context "callbacks" do
+    before do
+      rebuild_model 'User' do
+        redisearch schema: {
+          first_name: :text
+        }
+      end
+      rebuild_model 'Company' do
+        redisearch schema: {
+          name: :text
+        }
+      end
+      User.reindex(recreate: true)
+      Company.reindex(recreate: true)
+    end
+
+    context "if callbacks its true" do
+      before do
+        RediSearch.callbacks(true) do
+          User.create
+          User.create
+          Company.create
+          Company.last.destroy
+        end
+      end
+
+      it "reindex elements after_commit" do
+        expect(User.redisearch_count).to eq 2
+      end
+
+      it "delete elements if destroyed" do
+        expect(Company.redisearch_count).to eq 0
+      end
+    end
+
+    context "if callbacks its false" do
+      before do
+        RediSearch.callbacks(false) do
+          User.create
+          User.create
+        end
+      end
+
+      it "do not reindex" do
+        expect(User.redisearch_count).to eq 0
+      end
+    end
+
+    context "if callbacks its inline" do
+      before do
+        RediSearch.callbacks(:inline) do
+          User.create
+          User.create
+          Company.create
+          Company.last.destroy
+        end
+      end
+
+      it "reindex elements after_commit" do
+        expect(User.redisearch_count).to eq 2
+      end
+
+      it "delete elements if destroyed" do
+        expect(Company.redisearch_count).to eq 0
+      end
+    end
+
+    context "if callbacks its async", type: :job do
+      before do
+        RediSearch.callbacks(:async) do
+          User.create
+        end
+      end
+
+      it "enqueue a job" do
+        expect(enqueued_jobs.size).to eq 1
+      end
+    end
+  end
+end

--- a/spec/redisearch-rails/redisearch-rails_spec.rb
+++ b/spec/redisearch-rails/redisearch-rails_spec.rb
@@ -8,4 +8,8 @@ RSpec.describe RediSearch do
   it "has a client connection to Redis" do
     expect(RediSearch.client).not_to be nil
   end
+
+  it "respond to configuration methods" do
+    expect(RediSearch.queue_name).to be :redisearch
+  end
 end

--- a/spec/redisearch-rails/reindex_batches_job_spec.rb
+++ b/spec/redisearch-rails/reindex_batches_job_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe RediSearch::ReindexBatchesJob, type: :job do
+  before do
+    rebuild_model 'User' do
+      redisearch schema: {
+        first_name: :text
+      }
+    end
+
+    User.reindex(recreate: true)
+
+    (0..12).each do |name|
+      RediSearch.callbacks(false) do
+        User.create(first_name: "#{name} Jon")
+      end
+    end
+  end
+
+  subject { described_class }
+
+  context "perform_later" do
+    let(:job) { subject.perform_later("User", 3, 11, 10) }
+    it 'queues the job' do
+      expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+    end
+
+    it 'is in default queue' do
+      expect(subject.new.queue_name).to eq('redisearch')
+    end
+
+    it 'executes perform' do
+      expect(User.redisearch_count).to eq 0
+      perform_enqueued_jobs { job }
+      expect(User.redisearch_count).to eq 9
+    end
+  end
+end

--- a/spec/redisearch-rails/reindex_record_job_spec.rb
+++ b/spec/redisearch-rails/reindex_record_job_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe RediSearch::ReindexRecordJob, type: :job do
+  before do
+    rebuild_model 'User' do
+      redisearch schema: {
+        first_name: :text
+      }
+    end
+
+    User.reindex(recreate: true)
+
+    (0..12).each do |name|
+      RediSearch.callbacks(false) do
+        User.create(first_name: "#{name} Jon")
+      end
+    end
+  end
+
+  subject { described_class }
+
+  context "perform_later" do
+    let(:job) { subject.perform_later("User", 3) }
+
+    it 'queues the job' do
+      expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+    end
+
+    it 'is in default queue' do
+      expect(subject.new.queue_name).to eq('redisearch')
+    end
+
+    it 'executes perform' do
+      expect(User.redisearch_count).to eq 0
+      perform_enqueued_jobs { job }
+      expect(User.redisearch_count).to eq 1
+    end
+  end
+end

--- a/spec/redisearch-rails/reindex_spec.rb
+++ b/spec/redisearch-rails/reindex_spec.rb
@@ -16,12 +16,14 @@ describe RediSearch do
         }
         has_many :users
       end
-      company = Company.create(name: 'The Company')
-      company.users.create(first_name: 'Jon', last_name: 'Doe')
-      company.users.create(first_name: 'Jane', last_name: 'Doe')
+      RediSearch.callbacks(false) do
+        company = Company.create(name: 'The Company')
+        company.users.create(first_name: 'Jon', last_name: 'Doe')
+        company.users.create(first_name: 'Jane', last_name: 'Doe')
 
-      User.reindex
-      Company.reindex
+        User.reindex
+        Company.reindex
+      end
     end
 
     it "index all elements to rediseach service" do
@@ -35,6 +37,18 @@ describe RediSearch do
       end
 
       it "drop and reindex elements in rediseach service" do
+        expect(User.redisearch_count).to eq 1
+      end
+    end
+
+    context "delete records not persisted" do
+      before do
+        RediSearch.callbacks(true) do
+          User.last.destroy
+        end
+      end
+
+      it "drop deleted elements in rediseach service" do
         expect(User.redisearch_count).to eq 1
       end
     end


### PR DESCRIPTION
ActiveJobs for Reindex Async Batches and Simple Records

Callbacks handler (inline, false, async)
```
RediSearch.callbacks(false) do
  User.create
end
``` 
For disable callbacks on that block

## More Configs
Global Options on configuration:
```
      @index_prefix = nil
      @index_suffix = nil
      @queue_name = :redisearch
      @model_options = {}
```

separated reindex logic on other service